### PR TITLE
RandomLunchAllWeek Prevent bot from saying wrong things.

### DIFF
--- a/scripts/food.coffee
+++ b/scripts/food.coffee
@@ -31,8 +31,7 @@ module.exports = (robot) ->
     now = new Date().getHours()
     msg.send msg.random gifs  if now is 11 or now is 12
   robot.hear /lunch/i, (msg) ->
-  	if allWeekRandom
-  		return msg.send("(shrug) It's random lunch all week.")
+    return msg.send("(shrug) It's random lunch all week.") if allWeekRandom
     message = msg.message.text.toLowerCase()
     date = new Date().getDay()
     unless message.indexOf("monday") is -1


### PR DESCRIPTION
If lunch is random for the entire week, we should be able to prevent the bot from giving inaccurate information. I provided a toggle so it can easily be enabled/disabled.
