### PR TITLE
Fixed hyphenator.

### DIFF
--- a/scripts/hyphen.coffee
+++ b/scripts/hyphen.coffee
@@ -2,6 +2,7 @@
 #   Keaton Greve (keaton.greve)
 
 module.exports = (robot) ->
-  robot.hear /\s*(.*)[\s+|-]ass\s+(.*)/i, (msg) ->
-    if matches? and matches.length == 3
-      msg.send "Ha, more like: #{matches[1]} ass-#{matches[2]}"
+  robot.hear /[.*:]\s*(.*)[\s+|-]ass\s+(.*)/i, (msg) ->
+    matches = msg.match
+    if matches? and matches.length >= 3
+      msg.send "Ha, more like \"#{matches[1]} ass-#{matches[2]}\""


### PR DESCRIPTION
`matches` was a reference from my test jsfiddle script I wrote last week. that was useless since I have to use `msg.match`
