### PR TITLE
Business only triggers if there's a word break.

### DIFF
--- a/scripts/business.coffee
+++ b/scripts/business.coffee
@@ -2,5 +2,5 @@
 # 	Shows a haha, business image when anybody says business.
 
 module.exports = (robot) ->
-  robot.hear /business/i, (msg) ->
+  robot.hear /business\b/i, (msg) ->
     msg.send "https://s3.amazonaws.com/hudl-internal-assets/haha-business.jpg"


### PR DESCRIPTION
Hopefully this stops it from triggering on URLs.
Syntax based on umad.coffee.