### PR TITLE
Business now only triggers if it's by itself

### DIFF
--- a/scripts/business.coffee
+++ b/scripts/business.coffee
@@ -2,5 +2,5 @@
 # 	Shows a haha, business image when anybody says business.
 
 module.exports = (robot) ->
-  robot.hear /business\b/i, (msg) ->
+  robot.hear /(^|\s)business($|\s)/i, (msg) ->
     msg.send "https://s3.amazonaws.com/hudl-internal-assets/haha-business.jpg"


### PR DESCRIPTION
Actually tested this ish. The regex now looks for beginning of line `^` or whitespace `\s`, and end of line `$` or whitespace `\s`.

So `business`, `it's business time`, and `giving him the business` all work, but `businessman` and `url.business.com` won't.

Fixes #42.